### PR TITLE
Add synchronize call between MOFF and Save

### DIFF
--- a/LWA/LWA_bifrost.py
+++ b/LWA/LWA_bifrost.py
@@ -1052,6 +1052,7 @@ class MOFFCorrelatorOp(object):
                                     odata = ospan.data_view(numpy.complex64).reshape(oshape)
                                     accumulated_image = accumulated_image.reshape(oshape)
                                     odata[...] = accumulated_image
+                                    bifrost.device.stream_synchronize()
                                     
                                 curr_time = time.time()
                                 reserve_time = curr_time - prev_time

--- a/LWA/LWA_bifrost_DFT.py
+++ b/LWA/LWA_bifrost_DFT.py
@@ -1094,6 +1094,7 @@ class MOFFCorrelatorOp(object):
                                     odata = ospan.data_view(numpy.complex64).reshape(oshape)
                                     accumulated_image = accumulated_image.reshape(oshape)
                                     odata[...] = accumulated_image
+                                    bifrost.device.stream_synchronize()
                                     
                                 curr_time = time.time()
                                 reserve_time = curr_time - prev_time

--- a/LWA/LWA_bifrost_alt_ordering.py
+++ b/LWA/LWA_bifrost_alt_ordering.py
@@ -1056,6 +1056,7 @@ class MOFFCorrelatorOp(object):
                                     odata = ospan.data_view(numpy.complex64).reshape(oshape)
                                     accumulated_image = accumulated_image.reshape(oshape)
                                     odata[...] = accumulated_image
+                                    bifrost.device.stream_synchronize()
                                     
                                 curr_time = time.time()
                                 reserve_time = curr_time - prev_time


### PR DESCRIPTION
I'll just copy-paste Jayce's explanation because I don't fully understand it.
>The underlying problem was that all of the CUDA operations are done asynchronously.  Normally Bifrost forces a sync when the data cross a memory space boundary.  However, when using a CUDA-based ring you end up with data being written that isn't actually there until the memcpy completes.  The reserve on the ring doesn't know about this so when that reserve is released the next block starts to read.  That read can start before the copy finishes.
