### PR TITLE
Updates to `fits_equinox_update` branch

### DIFF
--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -793,7 +793,7 @@ class DecimationOp(object):
                             odata = ospan.data_view(np.uint8).reshape(oshape)
 
                             if do_truncate:
-                                sdata2 = idata[:, :self.nchan_out, :, :]
+                                sdata = idata[:, :self.nchan_out, :, :]
                                 if self.npol_out != npol:
                                     sdata = sdata[:, :, :, :self.npol_out]
                             else:

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -1060,8 +1060,10 @@ class MOFFCorrelatorOp(object):
                             if self.benchmark is True:
                                 timeg1 = time.time()
                             try:
+                                
                                 bf_vgrid.execute(udata, gdata)
                             except NameError:
+                                
                                 bf_vgrid = VGrid()
                                 bf_vgrid.init(self.locs, gphases, self.grid_size, polmajor=False)
                                 bf_vgrid.execute(udata, gdata)
@@ -1146,7 +1148,7 @@ class MOFFCorrelatorOp(object):
                                         np.ones(
                                             shape=(3, 1, nchan, nstand, npol ** 2),
                                             dtype=np.int32
-                                        ) * self.grid_size / 2,
+                                        ) * self.grid_size // 2,
                                         space="cuda",
                                     )
                                     autocorr_il = bifrost.ndarray(
@@ -1157,13 +1159,6 @@ class MOFFCorrelatorOp(object):
                                         space="cuda",
                                     )
 
-                                # Cross multiply to calculate autocorrs
-                                #bifrost.map(
-                                #    "a(i,j,k,l) += (b(i,j,k,l/2) * b(i,j,k,l%2).conj())",
-                                #    {"a": autocorrs, "b": udata, "t": self.ntime_gulp},
-                                #    axis_names=("i", "j", "k", "l"),
-                                #    shape=(self.ntime_gulp, nchan, nstand, npol ** 2),
-                                #)
                                 try:
                                      bf_auto.execute(udata, autocorrs)
                                 except NameError:
@@ -1174,16 +1169,11 @@ class MOFFCorrelatorOp(object):
                                     self.ntime_gulp, nchan, nstand, npol ** 2
                                 )
 
-
-                            #bifrost.map(
-                            #    "a(i,j,p,k,l) += b(0,i,j,p/2,k,l)*b(0,i,j,p%2,k,l).conj()",
-                            #    {"a": crosspol, "b": gdata},
-                            #    axis_names=("i", "j", "p", "k", "l"),
-                            #    shape=(self.ntime_gulp, nchan, npol ** 2, self.grid_size, self.grid_size),
-                            #)
                             try:
+                                
                                 bf_gmul.execute(gdata, crosspol)
                             except NameError:
+                                
                                 bf_gmul = XGrid()
                                 bf_gmul.init(self.grid_size, polmajor=False)
                                 bf_gmul.execute(gdata, crosspol)

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -892,7 +892,7 @@ class MOFFCorrelatorOp(object):
                 locname = "locations_%s_%i_%i_%i_%i_%i_%i_%.6f.npy" % (self.station.name, chan0, nchan, nstand, npol, self.ant_extent, self.grid_size, self.grid_resolution)
                 locname = os.path.join(os.path.dirname(__file__), locname)
                 try:
-                    loc_data = np.loadz(locname)
+                    loc_data = np.load(locname)
                     sampling_length = loc_data['sampling_length'].item()
                     locs = loc_data['locs'][...]
                     sll = loc_data['sll'].item()

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -21,6 +21,7 @@ from scipy.fftpack import fft
 
 from astropy.io import fits
 from astropy.time import Time, TimeDelta
+from astropy import units as u
 from astropy.coordinates import SkyCoord, FK5
 from astropy.constants import c as speed_of_light
 
@@ -37,7 +38,7 @@ import bifrost
 import bifrost.affinity
 from bifrost.address import Address as BF_Address
 from bifrost.udp_socket import UDPSocket as BF_UDPSocket
-from bifrost.packet_capture import PacketCaptureCallback, UDPCapture
+from bifrost.packet_capture import PacketCaptureCallback, UDPVerbsCapture as UDPCapture
 from bifrost.ring import Ring
 from bifrost.unpack import unpack as Unpack
 from bifrost.quantize import quantize as Quantize
@@ -237,9 +238,9 @@ def GenerateLocations(
     lsl_locs = lsl_locs.T
 
     lsl_locsf = lsl_locs[:, np.newaxis, np.newaxis, :] / sample_grid[np.newaxis, np.newaxis, :, np.newaxis]
-    lsl_locsf -= np.min(lsl_locsf, axis=3, keepdims=True)
-
+    
     # Centre locations slightly
+    lsl_locsf -= np.min(lsl_locsf, axis=3, keepdims=True)
     lsl_locsf += (grid_size - np.max(lsl_locsf, axis=3, keepdims=True)) / 2.
 
     # add ntime axis
@@ -537,7 +538,7 @@ class TBFOfflineCaptureOp(object):
 
         # Setup the ring metadata and gulp sizes
         ntime = data.shape[2]
-        nstand, npol = data.shape[0] / 2, 2
+        nstand, npol = data.shape[0] // 2, 2
         oshape = (ntime, nchan, nstand, npol)
         ogulp_size = ntime * nchan * nstand * npol * 1  # ci4
         self.oring.resize(ogulp_size)
@@ -596,7 +597,7 @@ class TBFOfflineCaptureOp(object):
 
                         # Quantization
                         try:
-                            Quantize(idata, qdata, scale=1. / np.sqrt(nchan))
+                            Quantize(idata, qdata, scale=1. / np.sqrt(nchan)) # TODO: check sqrt against main? I dont have this
                         except NameError:
                             qdata = bifrost.ndarray(shape=idata.shape, native=False, dtype="ci4")
                             Quantize(idata, qdata, scale=1.0)
@@ -963,6 +964,7 @@ class MOFFCorrelatorOp(object):
                     sampling_length = loc_data['sampling_length'].item()
                     locs = loc_data['locs'][...]
                     sll = loc_data['sll'].item()
+                    locs = np.around(locs)
                 except OSError:
                     sampling_length, locs, sll = GenerateLocations(
                         self.locations,
@@ -974,6 +976,7 @@ class MOFFCorrelatorOp(object):
                         grid_resolution=self.grid_resolution,
                     )
                     np.savez(locname, sampling_length=sampling_length, locs=locs, sll=sll)
+                    locs=np.around(locs)
                 try:
                     copy_array(self.locs, bifrost.ndarray(locs.astype(np.int32)))
                 except AttributeError:
@@ -1014,12 +1017,24 @@ class MOFFCorrelatorOp(object):
                     raise ValueError(
                         "Cannot write fits file without knowing polarization list"
                     )
-                ohdr_str = json.dumps(ohdr)
+
 
                 # Setup the kernels to include phasing terms for zenith
                 # Phases are Ntime x Nchan x Nstand x Npol x extent x extent
                 phasename = "phases_%s_%i_%i_%i_%i_%i_%i.npy" % (self.station.name, chan0, self.ntime_gulp, nchan, nstand, npol, self.ant_extent)
                 phasename = os.path.join(self.cache_dir, phasename)
+
+                # Zenith for LWA-SV
+                pce = np.deg2rad(88.0666283)
+                pca = np.deg2rad(90.9743763)
+
+                # Create Phase Center Vector
+                phase_center_sv = np.array([np.cos(pce)*np.sin(pca), np.cos(pce)*np.cos(pca), np.sin(pce)])
+                
+                ohdr["pc_elevation"] = pce
+                ohdr["pc_azimuth"] = pca
+                ohdr_str = json.dumps(ohdr) 
+                
                 try:
                     phases = np.load(phasename)
                 except OSError:
@@ -1031,13 +1046,13 @@ class MOFFCorrelatorOp(object):
                     for i in range(nstand):
                         # X
                         a = self.station.antennas[2 * i + 0]
-                        delay = a.cable.delay(freq) - a.stand.z / speed_of_light.value
+                        delay = a.cable.delay(freq) - np.dot(phase_center_sv,[a.stand.x,a.stand.y, a.stand.z]) / speed_of_light.value
                         phases[:, :, i, 0, :, :] = np.exp(2j * np.pi * freq * delay)
                         phases[:, :, i, 0, :, :] /= np.sqrt(a.cable.gain(freq))
                         if npol == 2:
                             # Y
                             a = self.station.antennas[2 * i + 1]
-                            delay = a.cable.delay(freq) - a.stand.z / speed_of_light.value
+                            delay = a.cable.delay(freq) - np.dot(phase_center_sv,[a.stand.x,a.stand.y, a.stand.z]) / speed_of_light.value
                             phases[:, :, i, 1, :, :] = np.exp(2j * np.pi * freq * delay)
                             phases[:, :, i, 1, :, :] /= np.sqrt(a.cable.gain(freq))
                         # Explicit bad and suspect antenna masking - this will
@@ -1104,6 +1119,7 @@ class MOFFCorrelatorOp(object):
                                 time1 = time.time()
 
                             udata = idata.copy(space="cuda")
+                            
                             if self.benchmark is True:
                                 time1a = time.time()
                                 print("  Input copy time: %f" % (time1a - time1))
@@ -1257,23 +1273,15 @@ class MOFFCorrelatorOp(object):
                                         1, nchan, npol ** 2, self.grid_size, self.grid_size
                                     )
                                     try:
-                                        bf_romein_autocorr.execute(autocorrs_av, autocorr_g)
+                                        bf_vgrid_autocorr.execute(autocorrs_av, autocorr_g)
                                     except NameError:
-                                        bf_romein_autocorr = Romein()
-                                        bf_romein_autocorr.init(
+                                        bf_vgrid_autocorr = VGrid()
+                                        bf_vgrid_autocorr.init(
                                             autocorr_lo, gacphases, self.grid_size, polmajor=False
                                         )
-                                        bf_romein_autocorr.execute(autocorrs_av, autocorr_g)
-                                    # try:
-                                    #     bf_vgrid_autocorr.execute(autocorrs_av, autocorr_g)
-                                    # except NameError:
-                                    #     bf_vgrid_autocorr = VGrid()
-                                    #     bf_vgrid_autocorr.init(
-                                    #         autocorr_lo, gacphases, self.grid_size, polmajor=False
-                                    #     )
-                                    #     bf_vgrid_autocorr.execute(autocorrs_av, autocorr_g)
+                                        bf_vgrid_autocorr.execute(autocorrs_av, autocorr_g)
                                     autocorr_g = autocorr_g.reshape(1 * nchan * npol ** 2, self.grid_size, self.grid_size)
-                                    # autocorr_g = romein_float(autocorrs_av,autocorr_g,autocorr_il,autocorr_lx,autocorr_ly,autocorr_lz,self.ant_extent,self.grid_size,nstand,nchan*npol**2)
+                                    
                                     # Inverse FFT
                                     try:
                                         ac_fft.execute(autocorr_g, autocorr_g, inverse=True)
@@ -1965,8 +1973,10 @@ class SaveOp(object):
             crit_pix_x = float(ihdr["grid_size_x"] / 2 + 1)
             # Need to correct for shift in center pixel when we flipped dec dimension
             # when writing npz, Only applies for even dimension size
-            crit_pix_y = float(ihdr["grid_size_y"] / 2 + 1) - (ihdr["grid_size_x"] + 1) % 2
-
+            crit_pix_y = float(ihdr["grid_size_y"] / 2 + 1) # - (ihdr["grid_size_x"] + 1) % 2
+            
+            
+            
             delta_x = -dtheta_x * 180.0 / np.pi
             delta_y = dtheta_y * 180.0 / np.pi
             delta_f = ihdr["bw"] / ihdr["nchan"]
@@ -1989,7 +1999,10 @@ class SaveOp(object):
 
                 if nints >= self.ints_per_file:
                     image = np.fft.fftshift(image, axes=(3, 4))
-                    image = image[:, :, :, ::-1, :]
+                    # image = image[:, :, :, ::-1, :] 
+                    # TODO: contentious debate about whether the above line is correct OR the complete picture. 
+                    #       maybe we need to flip x coords.
+                    #       maybe we need to offset ourselves by a pixel?
 
                     # Restructure data in preparation to stuff into fits
                     # Now (Ntimes, Npol, Nfreq, y, x)
@@ -2016,12 +2029,13 @@ class SaveOp(object):
                     )
 
                     time_array = t0 + np.arange(nints) * dt
-
                     lsts = time_array.sidereal_time("apparent")
-                    coords = SkyCoord(
-                        lsts.deg, ihdr["latitude"], obstime=time_array, unit="deg"
-                    ).transform_to(FK5(equinox="J2000"))
 
+                    # Set Observer
+                    observinglocation = EarthLocation(lat = ihdr["latitude"]*u.deg , lon =ihdr["longitude"]*u.deg , height=1500*u.m)
+                    aa = AltAz(location=observinglocation, obstime = time_array, az = ihdr["pc_azimuth"]*u.rad , alt = ihdr["pc_elevation"]*u.rad)
+                    coords = SkyCoord(aa).transform_to(FK5(equinox="J2000"))
+                    
                     hdul = []
                     for im_num, d in enumerate(image):
                         hdu = fits.ImageHDU(data=d)

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -828,7 +828,11 @@ class MOFFCorrelatorOp(object):
         elif self.station == lwa1:
             locations[[i for i, a in enumerate(self.station.antennas[::2]) if a.stand.id in (35, 257, 258, 259, 260)], :] = 0.0
         self.locations = locations
-
+        
+        self.cache_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'cache')
+        if not os.path.exists(self.cache_dir):
+            os.mkdir(self.cache_dir)
+            
         self.grid_size = grid_size
         self.grid_resolution = grid_resolution
 
@@ -890,7 +894,7 @@ class MOFFCorrelatorOp(object):
 
                 freq = (chan0 + np.arange(nchan)) * CHAN_BW
                 locname = "locations_%s_%i_%i_%i_%i_%i_%i_%i_%.6f.npz" % (self.station.name, chan0, self.ntime_gulp, nchan, nstand, npol, self.ant_extent, self.grid_size, self.grid_resolution)
-                locname = os.path.join(os.path.dirname(__file__), locname)
+                locname = os.path.join(self.cache_dir, locname)
                 try:
                     loc_data = np.load(locname)
                     sampling_length = loc_data['sampling_length'].item()
@@ -952,7 +956,7 @@ class MOFFCorrelatorOp(object):
                 # Setup the kernels to include phasing terms for zenith
                 # Phases are Ntime x Nchan x Nstand x Npol x extent x extent
                 phasename = "phases_%s_%i_%i_%i_%i_%i_%i.npy" % (self.station.name, chan0, self.ntime_gulp, nchan, nstand, npol, self.ant_extent)
-                phasename = os.path.join(os.path.dirname(__file__), phasename)
+                phasename = os.path.join(self.cache_dir, phasename)
                 try:
                     phases = np.load(phasename)
                 except OSError:

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -802,7 +802,7 @@ class DecimationOp(object):
                                 gdata = idata.copy(space='cuda')
                                 adata = bifrost.zeros(
                                     shape=(self.ntime_gulp, self.nchan_out, nstand, self.npol_out),
-                                    dtype='ci4',
+                                    dtype='ci8',
                                     space='cuda'
                                 )
 

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -2117,6 +2117,8 @@ def gen_args(return_parser=False):
     group2.add_argument("--tbffile", type=str, help="TBF Data Path")
 
     group3 = parser.add_argument_group("Processing Options")
+    group3.add_argument("--cores", type=str, default="3,4,5,6,7", help="Comma separated list of CPU cores to bind to")
+    group3.add_argument("--gpu", type=int, default=0, help="GPU to bind to")
     group3.add_argument("--imagesize", type=int, default=64, help="1-D Image Size")
     group3.add_argument(
         "--imageres", type=float, default=1.79057, help="Image pixel size in degrees"
@@ -2231,8 +2233,8 @@ def main(args, parser):
     log.setLevel(logging.DEBUG)
 
     # Setup the cores and GPUs to use
-    cores = [3, 4, 5, 6, 7]
-    gpus = [0, 0, 0, 0, 0]
+    cores = [int(v) for v in args.cores.split(',')]
+    gpus = [args.gpu,]*len(cores)
 
     # Setup the signal handling
     ops = []

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -988,8 +988,9 @@ class MOFFCorrelatorOp(object):
                         ):
                             phases[:, :, i, :, :, :] = 0.0
                     phases = phases.conj()
-                    phases = bifrost.ndarray(phases)
                     np.save(phasename, phases)
+                phases = bifrost.ndarray(phases)
+                
                 try:
                     copy_array(gphases, phases)
                 except NameError:

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -45,6 +45,7 @@ from bifrost.proclog import ProcLog
 from bifrost.libbifrost import bf
 from bifrost.fft import Fft
 from bifrost.linalg import LinAlg
+from bifrost.romein import Romein
 
 from bifrost.ndarray import memset_array, copy_array
 from bifrost.device import set_device as BFSetGPU, get_device as BFGetGPU, set_devices_no_spin_cpu as BFNoSpinZone

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -1056,7 +1056,12 @@ class MOFFCorrelatorOp(object):
                             phases[:, :, i, :, :, :] = 0.0
                     phases = phases.conj()
                     np.save(phasename, phases)
-                acphases = np.abs(phases) + 0j
+                acphases = np.zeros(
+                    (1, nchan, nstand, npol**2, self.ant_extent, self.ant_extent),
+                    dtype=np.complex64
+                )
+                for i in range(npol**2):
+                    acphases[:,:,:,i,:,:] = np.abs(phases[0,:,:,i//2,:,:]*phases[0,:,:,i%2,:,:].conj())
                 acphases = acphases.astype(np.complex64)
                 phases = bifrost.ndarray(phases)
                 acphases = bifrost.ndarray(acphases)

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -763,6 +763,7 @@ class DecimationOp(object):
                 if nchan % self.nchan_out == 0:
                     do_truncate = False
                     act_chan_bw = CHAN_BW * (nchan // self.nchan_out)
+                    chan0 = chan0 + 0.5 * (nchan // self.nchan_out - 1)
                     self.log.info("Decimation: Running in averaging mode")
                 else:
                     self.log.info("Decimation: Running in truncation mode")

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -1249,22 +1249,22 @@ class MOFFCorrelatorOp(object):
                                     autocorr_g = autocorr_g.reshape(
                                         1, nchan, npol ** 2, self.grid_size, self.grid_size
                                     )
-                                    #try:
-                                    #    bf_romein_autocorr.execute(autocorrs_av, autocorr_g)
-                                    #except NameError:
-                                    #    bf_romein_autocorr = Romein()
-                                    #    bf_romein_autocorr.init(
-                                    #        autocorr_lo, autocorr_il, self.grid_size, polmajor=False
-                                    #    )
-                                    #    bf_romein_autocorr.execute(autocorrs_av, autocorr_g)
                                     try:
-                                        bf_vgrid_autocorr.execute(autocorrs_av, autocorr_g)
+                                        bf_romein_autocorr.execute(autocorrs_av, autocorr_g)
                                     except NameError:
-                                        bf_vgrid_autocorr = VGrid()
-                                        bf_vgrid_autocorr.init(
+                                        bf_romein_autocorr = Romein()
+                                        bf_romein_autocorr.init(
                                             autocorr_lo, gacphases, self.grid_size, polmajor=False
                                         )
-                                        bf_vgrid_autocorr.execute(autocorrs_av, autocorr_g)
+                                        bf_romein_autocorr.execute(autocorrs_av, autocorr_g)
+                                    # try:
+                                    #     bf_vgrid_autocorr.execute(autocorrs_av, autocorr_g)
+                                    # except NameError:
+                                    #     bf_vgrid_autocorr = VGrid()
+                                    #     bf_vgrid_autocorr.init(
+                                    #         autocorr_lo, gacphases, self.grid_size, polmajor=False
+                                    #     )
+                                    #     bf_vgrid_autocorr.execute(autocorrs_av, autocorr_g)
                                     autocorr_g = autocorr_g.reshape(1 * nchan * npol ** 2, self.grid_size, self.grid_size)
                                     # autocorr_g = romein_float(autocorrs_av,autocorr_g,autocorr_il,autocorr_lx,autocorr_ly,autocorr_lz,self.ant_extent,self.grid_size,nstand,nchan*npol**2)
                                     # Inverse FFT

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -1055,7 +1055,8 @@ class MOFFCorrelatorOp(object):
                             phases[:, :, i, :, :, :] = 0.0
                     phases = phases.conj()
                     np.save(phasename, phases)
-                acphases = np.abs(phases, dtype=np.complex64)
+                acphases = np.abs(phases) + 0j
+                acphases = acphases.astype(np.complex64)
                 phases = bifrost.ndarray(phases)
                 acphases = bifrost.ndarray(acphases)
                 

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -1065,15 +1065,9 @@ class MOFFCorrelatorOp(object):
                                 bf_vgrid = VGrid()
                                 bf_vgrid.init(self.locs, gphases, self.grid_size, polmajor=False)
                                 bf_vgrid.execute(udata, gdata)
-
-                            #try:
-                            #    bf_romein.execute(udata, gdata)
-                            #except NameError:
-                            #    bf_romein = Romein()
-                            #    bf_romein.init(self.locs, gphases, self.grid_size, polmajor=False)
-                            #    bf_romein.execute(udata, gdata)
-                            gdata = gdata.reshape(self.ntime_gulp * nchan * npol, self.grid_size, self.grid_size)
-                            # gdata = self.LinAlgObj.matmul(1.0, udata, bfantgridmap, 0.0, gdata)
+                            gdata = gdata.reshape(
+                                self.ntime_gulp * nchan * npol, self.grid_size, self.grid_size
+                            )
                             if self.benchmark is True:
                                 timeg2 = time.time()
                                 print("  Grid time: %f" % (timeg2 - timeg1))
@@ -1097,7 +1091,6 @@ class MOFFCorrelatorOp(object):
                                 timefft2 = time.time()
                                 print("  FFT time: %f" % (timefft2 - timefft1))
 
-                            # print("Accum: %d"%accum,end='\n')
                             if self.newflag is True:
                                 try:
                                     crosspol = crosspol.reshape(

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -786,6 +786,7 @@ class DecimationOp(object):
                             if do_truncate:
                                 sdata = idata[:, :self.nchan_out, :, :]
                             else:
+                                sdata = idata[...]
                                 sdata = sdata.reshape(
                                     self.ntime_gulp, -1, nchan // self.nchan_out, nstand, npol
                                 )

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -786,11 +786,10 @@ class DecimationOp(object):
                             if do_truncate:
                                 sdata = idata[:, :self.nchan_out, :, :]
                             else:
-                                sdata = idata[...]
-                                sdata = sdata.reshape(
+                                sdata = idata.reshape(
                                     self.ntime_gulp, -1, nchan // self.nchan_out, nstand, npol
                                 )
-                                sdata = sdate.mean(axis=2)
+                                sdata = sdata.mean(axis=2)
 
                             if self.npol_out != npol:
                                 sdata = sdata[:, :, :, :self.npol_out]

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -1174,7 +1174,7 @@ class MOFFCorrelatorOp(object):
                                      bf_auto.init(self.locs, polmajor=False)
                                      bf_auto.execute(udata, autocorrs)
                                 autocorrs = autocorrs.reshape(
-                                self.ntime_gulp, nchan, nstand, npol ** 2
+                                    self.ntime_gulp, nchan, nstand, npol ** 2
                                 )
 
 

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -22,7 +22,7 @@ from scipy.fftpack import fft
 from astropy.io import fits
 from astropy.time import Time, TimeDelta
 from astropy import units as u
-from astropy.coordinates import SkyCoord, FK5
+from astropy.coordinates import SkyCoord, FK5, EarthLocation, AltAz
 from astropy.constants import c as speed_of_light
 
 import datetime

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -770,6 +770,7 @@ class DecimationOp(object):
                 self.log.info("Decimation: Channel bandwidth is %.3f kHz", act_chan_bw/1e3)
                 
                 ohdr = ihdr.copy()
+                ohdr["chan0"] = chan0
                 ohdr["nchan"] = self.nchan_out
                 ohdr["npol"] = self.npol_out
                 ohdr["cfreq"] = chan0 * CHAN_BW + 0.5 * (self.nchan_out - 1) * act_chan_bw

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -746,8 +746,8 @@ class DecimationOp(object):
                 ishape = (self.ntime_gulp, nchan, nstand, npol)
                 ogulp_size = self.ntime_gulp * self.nchan_out * nstand * self.npol_out * 1  # ci4
                 oshape = (self.ntime_gulp, self.nchan_out, nstand, self.npol_out)
-                self.iring.resize(igulp_size, buffer_factor= 8)
-                self.oring.resize(ogulp_size, buffer_factor= 128)  # , obuf_size)
+                self.iring.resize(igulp_size, buffer_factor= 5)
+                self.oring.resize(ogulp_size, buffer_factor= 10)  # , obuf_size)
 
                 ohdr = ihdr.copy()
                 ohdr["nchan"] = self.nchan_out
@@ -998,8 +998,8 @@ class MOFFCorrelatorOp(object):
 
                 oshape = (1, nchan, npol ** 2, self.grid_size, self.grid_size)
                 ogulp_size = nchan * npol ** 2 * self.grid_size * self.grid_size * 8
-                self.iring.resize(igulp_size, buffer_factor=128)
-                self.oring.resize(ogulp_size, buffer_factor=256)
+                self.iring.resize(igulp_size, buffer_factor=10)
+                self.oring.resize(ogulp_size, buffer_factor=10)
                 prev_time = time.time()
                 with oring.begin_sequence(time_tag=iseq.time_tag, header=ohdr_str) as oseq:
                     iseq_spans = iseq.read(igulp_size)

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -889,7 +889,7 @@ class MOFFCorrelatorOp(object):
                 itshape = (self.ntime_gulp, nchan, nstand, npol)
 
                 freq = (chan0 + np.arange(nchan)) * CHAN_BW
-                locname = "locations_%s_%i_%i_%i_%i_%i_%i_%.6f.npy" % (self.station.name, chan0, nchan, nstand, npol, self.ant_extent, self.grid_size, self.grid_resolution)
+                locname = "locations_%s_%i_%i_%i_%i_%i_%i_%.6f.npz" % (self.station.name, chan0, nchan, nstand, npol, self.ant_extent, self.grid_size, self.grid_resolution)
                 locname = os.path.join(os.path.dirname(__file__), locname)
                 try:
                     loc_data = np.load(locname)

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -889,7 +889,7 @@ class MOFFCorrelatorOp(object):
                 itshape = (self.ntime_gulp, nchan, nstand, npol)
 
                 freq = (chan0 + np.arange(nchan)) * CHAN_BW
-                locname = "locations_%s_%i_%i_%i_%i_%i_%i_%.6f.npz" % (self.station.name, chan0, nchan, nstand, npol, self.ant_extent, self.grid_size, self.grid_resolution)
+                locname = "locations_%s_%i_%i_%i_%i_%i_%i_%i_%.6f.npz" % (self.station.name, chan0, self.ntime_gulp, nchan, nstand, npol, self.ant_extent, self.grid_size, self.grid_resolution)
                 locname = os.path.join(os.path.dirname(__file__), locname)
                 try:
                     loc_data = np.load(locname)
@@ -951,7 +951,7 @@ class MOFFCorrelatorOp(object):
 
                 # Setup the kernels to include phasing terms for zenith
                 # Phases are Ntime x Nchan x Nstand x Npol x extent x extent
-                phasename = "phases_%s_%i_%i_%i_%i_%i.npy" % (self.station.name, chan0, nchan, nstand, npol, self.ant_extent)
+                phasename = "phases_%s_%i_%i_%i_%i_%i_%i.npy" % (self.station.name, chan0, self.ntime_gulp, nchan, nstand, npol, self.ant_extent)
                 phasename = os.path.join(os.path.dirname(__file__), phasename)
                 try:
                     phases = np.load(phasename)

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -816,7 +816,7 @@ class DecimationOp(object):
                                             
                                             #pragma unroll
                                             for(int m=0; m<{navg}; m++) {{
-                                                jF = j*{avg} + m;
+                                                jF = j*{navg} + m;
                                                 sample = b(i,jF,k,l).real_imag;
                                                 re += ((signed char)  (sample & 0xF0))       / 16;
                                                 im += ((signed char) ((sample & 0x0F) << 4)) / 16;

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -816,7 +816,7 @@ class DecimationOp(object):
                                             
                                             #pragma unroll
                                             for(int m=0; m<{navg}; m++) {{
-                                                jF = j*DECIM + m;
+                                                jF = j*{avg} + m;
                                                 sample = b(i,jF,k,l).real_imag;
                                                 re += ((signed char)  (sample & 0xF0))       / 16;
                                                 im += ((signed char) ((sample & 0x0F) << 4)) / 16;

--- a/LWA_EPIC/LWA_EPIC.py
+++ b/LWA_EPIC/LWA_EPIC.py
@@ -798,7 +798,7 @@ class DecimationOp(object):
                                     Unpack(udata, cdata)
                                 except NameError:
                                     cdata = bifrost.zeros(
-                                        shape=idata.shape
+                                        shape=idata.shape,
                                         dtype=np.complex64
                                     )
                                     Unpack(udata, cdata)
@@ -812,7 +812,7 @@ class DecimationOp(object):
                                     Quantize(cdata, sdata)
                                 except NameError:
                                     qdata = bifrost.zeros(
-                                        shape=cdata.shape
+                                        shape=cdata.shape,
                                         dtype='ci4'
                                     )
                                     Quantize(cdata, sdata)


### PR DESCRIPTION
This PR makes a few changes to the `fits_equinox_update` branch.  They are:
 * Caching of antenna location/phasing information to disk to reduce startup times,
 * Smaller intermediate buffer sizes to reduce memory usage,
 * A modified `DecimationOp` block that will allow channels to be average together, and
 * New --cores and --gpu command line flags to control binding.